### PR TITLE
http instead of ssh git clone

### DIFF
--- a/workshop/Lab3/README.md
+++ b/workshop/Lab3/README.md
@@ -10,7 +10,7 @@ Before we work with the application we need to clone a github repo from which we
 all our configuration files.
 
 ``` 
-	$git clone git@github.com:IBM/guestbook.git
+	$git clone https://github.com/IBM/guestbook.git
 ```
 Change directory by running the command `cd guestbook`. You will find all the configurations files for this exercise under the directory `v1`.
 


### PR DESCRIPTION
`git@github` is an ssh login, which will not work with no configuration on the users part.

resolves #24 