### PR TITLE
move debugging tips to separate optional lab

### DIFF
--- a/workshop/Lab3/README.md
+++ b/workshop/Lab3/README.md
@@ -383,21 +383,3 @@ $ kubectl delete -f redis-slave-deployment.yaml
 $ kubectl delete -f redis-master-service.yaml 
 $ kubectl delete -f redis-master-deployment.yaml
 ```
-
-//TODO
-Advanced debugging techniques to reach your pods.
-
-You can look at the logs of any of the pods running under your deployments as follows
-```
-    $ kubectl logs <podname>
-```
-
-Describe command gives you more information about a pod or deployment
-```
-    $ kubectl describe <deployment>
-```
-
-Endpoint resource can be used to see all the service endpoints.
-```
-    $ kubectl get endpoints <service>
-```

--- a/workshop/LabD/README.md
+++ b/workshop/LabD/README.md
@@ -1,0 +1,65 @@
+# Optional Debugging Lab - Tips and Tricks for Debugging Applications in Kubernetes
+
+Advanced debugging techniques to reach your pods.
+
+## Pod Logs
+
+You can look at the logs of any of the pods running under your deployments as follows
+
+```console
+$ kubectl logs <podname>
+```
+
+Remember that if you have multiple containers running in your pod, you
+have to specify the specific container you want to see logs from.
+
+```console
+$ kubectl logs <pod-name> <container-name>
+```
+
+This subcommand operates like `tail`. Including the `-f` flag will
+continue to stream the logs live once the current time is reached.
+
+
+## kubectl edit and vi
+
+By default, on many Linux and macOS systems, you will be dropped into the editor `vi`.
+```
+export EDITOR=nano
+```
+
+On Windows, a copy of `notepad.exe` will be opened with the contents of the file.
+
+## busybox pod
+
+For debugging live, this command frequently helps me:
+```console
+kubectl run bb --image busybox --restart=Never -it --rm
+```
+
+In the busybox image is a basic shell that contains useful utilities.
+
+Utils I often use are `nslookup` and `wget`. 
+
+`nslookup` is useful for testing DNS resolution in a pod.
+
+`wget` is useful for trying to do network requests.
+
+## Service Endpoints
+
+Endpoint resource can be used to see all the service endpoints.
+```console
+$ kubectl get endpoints <service>
+```
+
+## ImagePullPolicy
+
+By default Kubernetes will only pull the image on first use. This can
+be confusing during development when you expect changes to show up.
+
+You should be aware of the three `ImagePullPolicy`s:
+ - IfNotPresent - the default, only request the image if not present.
+ - Always - always request the image.
+ - Never
+
+More details on image management may be [found here](https://kubernetes.io/docs/concepts/containers/images/).

--- a/workshop/README.md
+++ b/workshop/README.md
@@ -170,4 +170,4 @@ IBM Cloud provides the capability to run applications in containers on Kubernete
 
 [Lab 4](Lab4): How to enable your application so Kubernetes can automatically monitor and recover your applications with no user intervention.
 
-[Lab D](LabD): Debugging tips and tricks to help you along your Kubernetes journey. This lab is useful reference that does not follow in a specefic sequence of the other labs. 
+[Lab D](LabD): Debugging tips and tricks to help you along your Kubernetes journey. This lab is useful reference that does not follow in a specific sequence of the other labs. 

--- a/workshop/README.md
+++ b/workshop/README.md
@@ -165,3 +165,9 @@ IBM Cloud provides the capability to run applications in containers on Kubernete
 [Lab 1](Lab1): This lab walks through creating and deploying a simple "guestbook" app written in Go as a net/http Server and accessing it.
 
 [Lab 2](Lab2): Builds on lab 1 to expand to a more resilient setup which can survive having containers fail and recover. Lab 2 will also walk through basic services you need to get started with Kubernetes and the IBM Cloud Container Service
+
+[Lab 3](Lab3): Builds on lab 2 by increasing the capabilities of the deployed Guestbook application. This lab covers basic distributed application design and how kubernetes helps you use standard design practices.
+
+[Lab 4](Lab4): How to enable your application so Kubernetes can automatically monitor and recover your applications with no user intervention.
+
+[Lab D](LabD): Debugging tips and tricks to help you along your Kubernetes journey. This lab is useful reference that does not follow in a specefic sequence of the other labs. 


### PR DESCRIPTION
this is a grab bag of topics that could possibly included in another lab at point of use, but I feel is better isolated to a separate location for reference.