### PR TITLE
Converted from `bx` to `ibmcloud`

### DIFF
--- a/workshop/Lab0/README.md
+++ b/workshop/Lab0/README.md
@@ -14,19 +14,19 @@ If you already have the CLIs and plug-ins, you can skip this lab and proceed to 
 # Install the IBM Cloud command-line interface
 
 1. As a prerequisite for the IBM Cloud Container Service plug-in, install the [IBM Cloud command-line interface](https://clis.ng.bluemix.net/ui/home.html). Once installed, you can access IBM Cloud from your command-line with the prefix `bx`.
-2. Log in to the IBM Cloud CLI: `bx login`.
+2. Log in to the IBM Cloud CLI: `ibmcloud login`.
 3. Enter your IBM Cloud credentials when prompted.
 
-   **Note:** If you have a federated ID, use `bx login --sso` to log in to the IBM Cloud CLI. Enter your user name, and use the provided URL in your CLI output to retrieve your one-time passcode. You know you have a federated ID when the login fails without the `--sso` and succeeds with the `--sso` option.
+   **Note:** If you have a federated ID, use `ibmcloud login --sso` to log in to the IBM Cloud CLI. Enter your user name, and use the provided URL in your CLI output to retrieve your one-time passcode. You know you have a federated ID when the login fails without the `--sso` and succeeds with the `--sso` option.
 
 # Install the IBM Cloud Container Service plug-in
 1. To create Kubernetes clusters and manage worker nodes, install the IBM Cloud Container Service plug-in:
-   ```bx plugin install container-service -r Bluemix```
+   ```ibmcloud plugin install container-service -r Bluemix```
 
    **Note:** The prefix for running commands by using the IBM Cloud Container Service plug-in is `bx cs`.
 
 2. To verify that the plug-in is installed properly, run the following command:
-```bx plugin list```
+```ibmcloud plugin list```
 
    The IBM Cloud Container Service plug-in is displayed in the results as `container-service`.
 

--- a/workshop/Lab1/README.md
+++ b/workshop/Lab1/README.md
@@ -9,12 +9,12 @@ If you haven't already:
 1. Install the IBM Cloud CLIs and login, as described in [Lab 0](../Lab0/README.md).
 2. Provision a cluster:
 
-   ```$ bx cs cluster-create --name <name-of-cluster>```
+   ```$ ibmcloud cs cluster-create --name <name-of-cluster>```
 
 Once the cluster is provisioned, the kubernetes client CLI `kubectl` needs to be
 configured to talk to the provisioned cluster.
 
-1. Run `$ bx cs cluster-config <name-of-cluster>`, and set the `KUBECONFIG`
+1. Run `$ ibmcloud cs cluster-config <name-of-cluster>`, and set the `KUBECONFIG`
    environment variable based on the output of the command. This will
    make your `kubectl` client point to your new Kubernetes cluster.
 
@@ -75,10 +75,10 @@ that has already been built and uploaded to DockerHub under the name
 
 5. `guestbook` is now running on your cluster, and exposed to the internet. We need to find out where it is accessible.
    The worker nodes running in the container service get external IP addresses.
-   Run `$ bx cs workers <name-of-cluster>`, and note the public IP listed on the `<public-IP>` line.
+   Run `$ ibmcloud cs workers <name-of-cluster>`, and note the public IP listed on the `<public-IP>` line.
    
    ```console
-   $ bx cs workers osscluster
+   $ ibmcloud cs workers osscluster
    OK
    ID                                                 Public IP        Private IP     Machine Type   State    Status   Zone    Version  
    kube-hou02-pa1e3ee39f549640aebea69a444f51fe55-w1   173.193.99.136   10.76.194.30   free           normal   Ready    hou02   1.5.6_1500*

--- a/workshop/Lab2/README.md
+++ b/workshop/Lab2/README.md
@@ -147,7 +147,7 @@ To update and roll back:
 
    `$ kubectl describe service guestbook`
    and
-   `$ bx cs workers <name-of-cluster>`
+   `$ ibmcloud cs workers <name-of-cluster>`
 
    To verify that you're running "v2" of guestbook, look at the title of the page,
    it should now be `Guestbook - v2`

--- a/workshop/Lab3/README.md
+++ b/workshop/Lab3/README.md
@@ -161,7 +161,7 @@ Deployment container spec.
 
   `$ kubectl describe service guestbook`
   and
-  `$ bx cs workers <name-of-cluster>`
+  `$ ibmcloud cs workers <name-of-cluster>`
 
 # 2. Connect to a back-end service.
 

--- a/workshop/Lab4/README.md
+++ b/workshop/Lab4/README.md
@@ -40,7 +40,7 @@ In this example, we have defined a HTTP liveness probe to check health of the co
 3. Open a browser and check out the app. To form the URL, combine the IP with the NodePort that was specified in the configuration script. To get the public IP address for the worker node:
 
    ```
-   bx cs workers <cluster-name>
+   ibmcloud cs workers <cluster-name>
    ```
 
    In a browser, you'll see a success message. If you do not see this text, don't worry. This app is designed to go up and down.

--- a/workshop/README.md
+++ b/workshop/README.md
@@ -54,9 +54,9 @@ Containers allow you to share the host OS. This reduces duplication while still 
 Before we dive into Kubernetes, you need to provision a cluster for your containerized app. Then you won't have to wait for it to be ready for the subsequent labs. 
 
 1. You must install the CLIs per https://console.ng.bluemix.net/docs/containers/cs_cli_install.html. If you do not yet have these CLIs and the Kubernetes CLI, do [lab 0](Lab0) before starting the course.
-2. If you haven't already, provision a cluster. This can take a few minutes, so let it start first: `bx cs cluster-create --name <name-of-cluster>`
-3. After creation, before using the cluster, make sure it has completed provisioning and is ready for use. Run `bx cs clusters` and make sure that your cluster is in state "deployed".  
-4. Then use `bx cs workers <name-of-cluster>` and make sure that all worker nodes are in state "normal" with Status "Ready".
+2. If you haven't already, provision a cluster. This can take a few minutes, so let it start first: `ibmcloud cs cluster-create --name <name-of-cluster>`
+3. After creation, before using the cluster, make sure it has completed provisioning and is ready for use. Run `ibmcloud cs clusters` and make sure that your cluster is in state "deployed".  
+4. Then use `ibmcloud cs workers <name-of-cluster>` and make sure that all worker nodes are in state "normal" with Status "Ready".
 
 # Kubernetes and containers: an overview
 


### PR DESCRIPTION
`bx` has been deprecated and ibmcloud is the correct command.

Signed-off-by: JJ Asghar <jja@ibm.com>